### PR TITLE
add .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+
+python:
+  - "3.6"
+  - "3.7"
+
+install:
+  - pip install pipenv
+  - pipenv install --dev
+
+script:
+  - pipenv run pytest
+  - pipenv run black --diff


### PR DESCRIPTION
travisでCIテストを走らせるようにした。

現状、Pythonは3.6と3.7にした。
テストは、pytestと、ついでにblackがかかってるかも確認する。
テストが増えたら、blackは別のジョブとかにしたほうがよろしいかな。